### PR TITLE
Adding logrotate config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 ntp_driftfile: /var/lib/ntp/ntp.drift
 
 # Enable this if you want statistics to be logged.
+# Must not end with a slash
 ntp_statsdir: false
 
 ntp_statistics:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,3 +17,13 @@
     mode: 0644
   notify: restart ntp
   tags: [configuration, ntp, ntp-configuration]
+
+- name: add logrotate configuration
+  template:
+    src: templates/etc/logrotate.d/ntpd.j2
+    dest: /etc/logrotate.d/ntpd
+    owner: root
+    group: root
+    mode: 0644
+  when: 'ntp_statsdir|bool'
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,4 +26,5 @@
     group: root
     mode: 0644
   when: 'ntp_statsdir|bool'
+  tags: [configuration, ntp, ntp-configuration]
 

--- a/templates/etc/logrotate.d/ntpd.j2
+++ b/templates/etc/logrotate.d/ntpd.j2
@@ -1,5 +1,5 @@
 # {{ ansible_managed }}
-{{ ntp_statsdir }}/*.log {
+{{ ntp_statsdir }}/* {
         weekly
         missingok
         rotate 8

--- a/templates/etc/logrotate.d/ntpd.j2
+++ b/templates/etc/logrotate.d/ntpd.j2
@@ -1,0 +1,11 @@
+# {{ ansible_managed }}
+{{ ntp_statsdir }}/*.log {
+        weekly
+        missingok
+        rotate 8
+        compress
+        delaycompress
+        notifempty
+        copytruncate
+}
+


### PR DESCRIPTION
Since every log should be rotated, this PR enables logrotation when `ntp_statsdir` is set.