### PR TITLE
Fix deprecation warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,11 +2,10 @@
 ---
 - name: install
   apt:
-    name: "{{ item }}"
+    name: "{{ ntp_dependencies }}"
     state: "{{ apt_install_state | default('latest') }}"
     update_cache: true
     cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
-  with_items: "{{ ntp_dependencies }}"
   tags:
     - configuration
     - ntp


### PR DESCRIPTION
When running in 2.7 running role throws following warning:
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: {{ item }}`, please use `name: '{{ snmpd_dependencies }}'` and remove the loop. This feature will
be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

This PR fixes it.